### PR TITLE
Fix is_audio_file()

### DIFF
--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -134,9 +134,8 @@ local function get_os()
 end
 
 local function is_audio_file()
-    if mp.get_property("track-list/0/type") == "audio" and mp.get_property("track-list/1/type") ~= "video" then
-        return true
-    elseif mp.get_property("track-list/0/albumart") == "yes" then
+    if mp.get_property_native('current-tracks/video/image') and
+        mp.get_property_native("current-tracks/video/albumart") then
         return true
     end
     return false


### PR DESCRIPTION
Fix https://github.com/po5/thumbfast/issues/10.

`options.audio` defaults to false, but it doesn't work for me.
![image](https://user-images.githubusercontent.com/50797982/191531216-37e53d14-bf40-4f41-a1aa-2697bdf422f9.png)
