### PR TITLE
Send disabled to osc on file_load

### DIFF
--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -470,6 +470,7 @@ local function file_load()
     local albumart = image and mp.get_property_native("current-tracks/video/albumart", false)
 
     disabled = (network and not options.network) or (albumart and not options.audio) or (image and not albumart)
+    info()
     if disabled then return end
 
     interval = math.min(math.max(mp.get_property_number("duration", 1) / options.max_thumbnails, options.interval), mp.get_property_number("duration", options.interval * options.min_thumbnails) / options.min_thumbnails)


### PR DESCRIPTION
Play a video, next file is a pure audio or something would make `disabled=true`, It's still `disabled=false` in osc's data. This fix it.