### PR TITLE
Fix odd thumbnail size

### DIFF
--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -68,8 +68,9 @@ local last_request_time = nil
 local last_display_time = 0
 
 local effective_w = options.max_width
-local effective_h = options.max_height
-local thumb_size = effective_w * effective_h * 4
+local generate_h = options.max_height
+local render_h = generate_h
+local thumb_size = effective_w * generate_h * 4
 
 local filters_reset = {["lavfi-crop"]=true, crop=true}
 local filters_runtime = {hflip=true, vflip=true}
@@ -154,7 +155,7 @@ local function vf_string(filters, full)
     end
 
     if full then
-        vf = vf.."scale=w="..effective_w..":h="..effective_h..par..",pad=w="..effective_w..":h="..effective_h..":x=(ow-iw)/2:y=(oh-ih)/2,format=bgra"
+        vf = vf.."scale=w="..effective_w..":h="..generate_h..par..",pad=w="..effective_w..":h="..generate_h..",format=bgra"
     end
 
     return vf
@@ -168,14 +169,15 @@ local function calc_dimensions()
     local scale = mp.get_property_number("display-hidpi-scale", 1)
 
     if width / height > options.max_width / options.max_height then
-        effective_w = math.floor(options.max_width * scale + 0.5)
-        effective_h = math.floor(height / width * effective_w + 0.5)
+        effective_w = math.floor(options.max_width * scale / 2) * 2
     else
-        effective_h = math.floor(options.max_height * scale + 0.5)
-        effective_w = math.floor(width / height * effective_h + 0.5)
+        local target_h = math.floor(options.max_height * scale + 0.5)
+        effective_w = math.floor(width / height * target_h / 2) * 2
     end
+    generate_h = math.ceil(height / width * effective_w / 2) * 2
+    render_h = math.floor(height / width * effective_w + 0.5)
 
-    thumb_size = effective_w * effective_h * 4
+    thumb_size = effective_w * generate_h * 4
 
     local v_par = mp.get_property_number("video-out-params/par", 1)
     if v_par == 1 then
@@ -186,9 +188,9 @@ local function calc_dimensions()
 end
 
 local function info()
-    local display_w, display_h = effective_w, effective_h
+    local display_w, display_h = effective_w, render_h
     if mp.get_property_number("video-params/rotate", 0) % 180 == 90 then
-        display_w, display_h = effective_h, effective_w
+        display_w, display_h = render_h, effective_w
     end
 
     local json, err = mp.utils.format_json({width=display_w, height=display_h, disabled=disabled, socket=options.socket, thumbnail=options.thumbnail, overlay_id=options.overlay_id})
@@ -395,7 +397,7 @@ local function thumb(time, r_x, r_y, script)
         last_index = index
         if x ~= last_x or y ~= last_y then
             last_x, last_y = x, y
-            display_img(effective_w, effective_h, time, mp.get_time(), script, true)
+            display_img(effective_w, render_h, time, mp.get_time(), script, true)
         end
         return
     end
@@ -409,13 +411,13 @@ local function thumb(time, r_x, r_y, script)
     if not spawned then
         spawn(seek_time)
         if can_generate then
-            display_img(effective_w, effective_h, time, cur_request_time, script)
-            mp.add_timeout(0.15, function() display_img(effective_w, effective_h, time, cur_request_time, script) end)
+            display_img(effective_w, render_h, time, cur_request_time, script)
+            mp.add_timeout(0.15, function() display_img(effective_w, render_h, time, cur_request_time, script) end)
             end
         return
     end
 
-    run("async seek "..seek_time.." absolute+keyframes", function() if can_generate then display_img(effective_w, effective_h, time, cur_request_time, script) end end)
+    run("async seek "..seek_time.." absolute+keyframes", function() if can_generate then display_img(effective_w, render_h, time, cur_request_time, script) end end)
 end
 
 local function clear()
@@ -430,7 +432,7 @@ end
 
 local function watch_changes()
     local old_w = effective_w
-    local old_h = effective_h
+    local old_h = generate_h
 
     calc_dimensions()
 
@@ -438,7 +440,7 @@ local function watch_changes()
     local rotate = mp.get_property_number("video-rotate", 0)
 
     if spawned then
-        if old_w ~= effective_w or old_h ~= effective_h or last_vf_reset ~= vf_reset or (last_rotate % 180) ~= (rotate % 180) or par ~= last_par then
+        if old_w ~= effective_w or old_h ~= generate_h or last_vf_reset ~= vf_reset or (last_rotate % 180) ~= (rotate % 180) or par ~= last_par then
             last_rotate = rotate
             -- mpv doesn't allow us to change output size
             run("quit")
@@ -457,7 +459,7 @@ local function watch_changes()
             end
         end
     else
-        if old_w ~= effective_w or old_h ~= effective_h or last_vf_reset ~= vf_reset or (last_rotate % 180) ~= (rotate % 180) or par ~= last_par then
+        if old_w ~= effective_w or old_h ~= generate_h or last_vf_reset ~= vf_reset or (last_rotate % 180) ~= (rotate % 180) or par ~= last_par then
             last_rotate = rotate
             info()
         end


### PR DESCRIPTION
Apparently scaling filters don't like odd resolutions, but always choosing even numbers leads to black borders.
The solution is to generate thumbnails with a different resolution then they are being rendered in.

The idea is that we can cut off thing from the bottom when rendering, but we can't cut off things from the right side, so use the highest width we are allowed to, and then use the appropriate height for that width + whatever is needed to fill up to `% 2 == 0`. That might result in a black border at the bottom of the generated image, but we can simply cut that off when displaying it, resulting in no visible black borders while still adhering to the "no odd numbers" rule.

Currently it's using resolutions for generating that are `% 2 == 0`, but according to @Natural-Harmonia-Gropius it might be necessary to increase it to `% 4 == 0`. We'll see if it causes problems for anyone.