### PR TITLE
Add --sws-scaler=fast-bilinear to subprocess

### DIFF
--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -256,7 +256,7 @@ local function spawn(time)
             "--ytdl-format=worst", "--demuxer-readahead-secs=0", "--demuxer-max-bytes=128KiB",
             "--vd-lavc-skiploopfilter=all", "--vd-lavc-software-fallback=1", "--vd-lavc-fast",
             "--vf="..vf_string(filters_all, true),
-            "--sws-allow-zimg=no", "--sws-fast=yes",
+            "--sws-allow-zimg=no", "--sws-fast=yes", "--sws-scaler=fast-bilinear",
             "--video-rotate="..last_rotate,
             "--ovc=rawvideo", "--of=image2", "--ofopts=update=1", "--o="..options.thumbnail
         }},


### PR DESCRIPTION
[#options-sws-fast](https://mpv.io/manual/master/#options-sws-fast) said: "You may need to set other options, like --sws-scaler."
Maybe there is a slight difference in performance, I hope.