### PR TITLE
No need for input or output in subprocess

### DIFF
--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -249,7 +249,7 @@ local function spawn(time)
 
     mp.command_native_async(
         {name = "subprocess", playback_only = true, args = {
-            "mpv", path, "--no-config", "--msg-level=all=no", "--idle", "--pause", "--keep-open=always",
+            "mpv", path, "--no-config", "--msg-level=all=no", "--idle", "--pause", "--keep-open=always", "--really-quiet", "--no-terminal",
             "--edition="..(mp.get_property_number("edition") or "auto"), "--vid="..(mp.get_property_number("vid") or "auto"), "--no-sub", "--no-audio",
             "--input-ipc-server="..options.socket,
             "--start="..time, "--hr-seek=no",


### PR DESCRIPTION
The `--really-quiet` might be unnecessary because there is already the `--msg-level=all=no`, but it doesn't hurt to make sure.