### PR TITLE
loadfile prep

### DIFF
--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -277,9 +277,9 @@ local function run(command, callback)
         seek_command = {"cmd", "/c", "echo "..command.." > \\\\.\\pipe\\" .. options.socket}
     elseif os_name == "Mac" then
         -- this doesn't work, on my system. not sure why.
-        seek_command = {"/usr/bin/env", "sh", "-c", "echo '"..command.."' | nc -w0 -U " .. options.socket}
+        seek_command = {"/usr/bin/env", "HISTSIZE=0", "sh", "-o", "nolog", "-c", "echo '"..command.."' | nc -w0 -U " .. options.socket}
     else
-        seek_command = {"/usr/bin/env", "sh", "-c", "echo '" .. command .. "' | socat - " .. options.socket}
+        seek_command = {"/usr/bin/env", "HISTSIZE=0", "sh", "-o", "nolog", "-c", "echo '" .. command .. "' | socat - " .. options.socket}
     end
 
     mp.command_native_async(


### PR DESCRIPTION
Due to your security concerns expressed in https://github.com/po5/thumbfast/pull/36#issuecomment-1264854896 I've looked into disabling history for the shells.

`cmd` never writes history to disk, so it should be fine as is (also haven't found any parameters for activating/deactivating it).
`sh` shouldn't write a history file, unless it's started in interactive mode, but adding `-o nolog` just to make sure. Bash however currently ignores that, so adding `HISTSIZE=0` as well.

You also mentioned that loadfile didn't work reliably for you. I suspect that has something to do with commands not being escaped. Escaping seems like a good idea in general.

---
The sub process always closes for me when switching files, even when no `quit` command gets sent. Do you know why?