### PR TITLE
Seek by file

### DIFF
--- a/thumbfast.conf
+++ b/thumbfast.conf
@@ -12,13 +12,6 @@ max_width=200
 # Overlay id
 overlay_id=42
 
-# Thumbnail interval in seconds set to 0 to disable (warning: high cpu usage)
-interval=6
-
-# Number of thumbnails
-min_thumbnails=6
-max_thumbnails=120
-
 # Spawn thumbnailer on file load for faster initial thumbnails
 spawn_first=no
 

--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -33,11 +33,6 @@ mp.utils = require "mp.utils"
 mp.options = require "mp.options"
 mp.options.read_options(options, "thumbfast")
 
-local os_name = ""
-
-math.randomseed(os.time())
-local unique = math.random(10000000)
-local init = false
 
 local spawned = false
 local network = false
@@ -126,6 +121,44 @@ local function get_os()
     return str_os_name
 end
 
+local os_name = get_os()
+
+if options.socket == "" then
+    if os_name == "Windows" then
+        options.socket = "thumbfast"
+    elseif os_name == "Mac" then
+        options.socket = "/tmp/thumbfast"
+    else
+        options.socket = "/tmp/thumbfast"
+    end
+end
+
+if options.thumbnail == "" then
+    if os_name == "Windows" then
+        options.thumbnail = os.getenv("TEMP").."\\thumbfast.out"
+    elseif os_name == "Mac" then
+        options.thumbnail = "/tmp/thumbfast.out"
+    else
+        options.thumbnail = "/tmp/thumbfast.out"
+    end
+end
+
+if options.seek == "" then
+    if os_name == "Windows" then
+        options.seek = os.getenv("TEMP").."\\thumbfast.seek"
+    elseif os_name == "Mac" then
+        options.seek = "/tmp/thumbfast.seek"
+    else
+        options.seek = "/tmp/thumbfast.seek"
+    end
+end
+
+math.randomseed(os.time())
+local unique = math.random(10000000)
+
+options.socket = options.socket .. unique
+options.thumbnail = options.thumbnail .. unique
+
 local function vf_string(filters, full)
     local vf = ""
     local vf_table = mp.get_property_native("vf")
@@ -202,37 +235,6 @@ local function spawn(time)
     local ytdl = open_filename and network and path ~= open_filename
     if ytdl then
         path = open_filename
-    end
-
-    if os_name == "" then
-        os_name = get_os()
-    end
-
-    if options.socket == "" then
-        if os_name == "Windows" then
-            options.socket = "thumbfast"
-        elseif os_name == "Mac" then
-            options.socket = "/tmp/thumbfast"
-        else
-            options.socket = "/tmp/thumbfast"
-        end
-    end
-
-    if options.thumbnail == "" then
-        if os_name == "Windows" then
-            options.thumbnail = os.getenv("TEMP").."\\thumbfast.out"
-        elseif os_name == "Mac" then
-            options.thumbnail = "/tmp/thumbfast.out"
-        else
-            options.thumbnail = "/tmp/thumbfast.out"
-        end
-    end
-
-    if not init then
-        -- ensure uniqueness
-        options.socket = options.socket .. unique
-        options.thumbnail = options.thumbnail .. unique
-        init = true
     end
 
     remove_thumbnail_files()

--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -346,21 +346,18 @@ local function request_seek()
 end
 
 local function check_new_thumb()
-    local finfo = mp.utils.file_info(options.thumbnail)
-    if not finfo then return false end
-
     -- the slave might start writing to the file after checking existance and
     -- validity but before actually moving the file, so move to a temporary
     -- location before validity check to make sure everything stays consistant
     -- and valid thumbnails don't get overwritten by invalid ones
     local tmp = options.thumbnail..".tmp"
     move_file(options.thumbnail, tmp)
+    local finfo = mp.utils.file_info(tmp)
+    if not finfo then return false end
     if first_file then
         request_seek()
         first_file = false
     end
-    finfo = mp.utils.file_info(tmp)
-    if not finfo then return false end
     local w, h = real_res(effective_w, effective_h, finfo.size)
     if w then -- only accept valid thumbnails
         move_file(tmp, options.thumbnail..".bgra")


### PR DESCRIPTION
Just like in my previous PR #41 I'm removing the interval and thumbnail count things because since we're not generating thumbnails in advance, they don't really make sense. Also removing them enables us to do exact seeks at the end of dragging.

Instead of seeking via commands sent through the socket, seek requests are now written to a file that is then read by the sub process. Not going though the socket has massive performance benefits.
Look how smooth it is now and compare it to the videos in #40.

https://user-images.githubusercontent.com/8932183/194593907-ab308510-011f-4b13-aeef-aeb8878d0d31.mp4

