### PR TITLE
no need for socat and netcat

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Supports web videos e.g. YouTube (disabled by default), mixed aspect ratio video
 ## Requirements
 Windows: None, works out of the box
 
-Linux: socat, already installed on most systems
+Linux: None, works out of the box
 
 Mac: None, works out of the box
 


### PR DESCRIPTION
Here's another implementation that optimizes communication with subprocesses (yeah, I know there are a lot of similar PRs).

It can communicate directly with sockets on all platforms.

ref: https://mpv.io/manual/master/#alternative-ways-of-starting-clients