### PR TITLE
Exact seek no interval

### DIFF
--- a/thumbfast.conf
+++ b/thumbfast.conf
@@ -12,13 +12,6 @@ max_width=200
 # Overlay id
 overlay_id=42
 
-# Thumbnail interval in seconds set to 0 to disable (warning: high cpu usage)
-interval=6
-
-# Number of thumbnails
-min_thumbnails=6
-max_thumbnails=120
-
 # Spawn thumbnailer on file load for faster initial thumbnails
 spawn_first=no
 

--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -19,14 +19,6 @@ local options = {
     -- Overlay id
     overlay_id = 42,
 
-    -- Thumbnail interval in seconds, set to 0 to disable (warning: high cpu usage)
-    -- Clamped to min_thumbnails and max_thumbnails
-    interval = 6,
-
-    -- Number of thumbnails
-    min_thumbnails = 6,
-    max_thumbnails = 120,
-
     -- Spawn thumbnailer on file load for faster initial thumbnails
     spawn_first = false,
 
@@ -46,10 +38,6 @@ local options = {
 mp.utils = require "mp.utils"
 mp.options = require "mp.options"
 mp.options.read_options(options, "thumbfast")
-
-if options.min_thumbnails < 1 then
-    options.min_thumbnails = 1
-end
 
 local winapi = {}
 if options.use_lua_io then
@@ -94,7 +82,6 @@ local init = false
 local spawned = false
 local network = false
 local disabled = false
-local interval = 0
 
 local x = nil
 local y = nil
@@ -362,19 +349,6 @@ local function run(command)
     end
 end
 
-local function thumb_index(thumbtime)
-    return math.floor(thumbtime / interval)
-end
-
-local function index_time(index, thumbtime)
-    if interval > 0 then
-        local time = index * interval
-        return time + interval / 3
-    else
-        return thumbtime
-    end
-end
-
 local function draw(w, h, script)
     if not w or not show_thumbnail then return end
     local display_w, display_h = w, h
@@ -489,20 +463,17 @@ local function thumb(time, r_x, r_y, script)
         x, y = math.floor(r_x + 0.5), math.floor(r_y + 0.5)
     end
 
-    local index = thumb_index(time)
-    local seek_time = index_time(index, time)
-
     script_name = script
-    if last_x ~= x or last_y ~= y or seek_time ~= last_seek_time or not show_thumbnail then
+    if last_x ~= x or last_y ~= y or not show_thumbnail then
         show_thumbnail = true
         last_x = x
         last_y = y
         draw(real_w, real_h, script)
     end
 
-    if seek_time == last_seek_time then return end
-    last_seek_time = seek_time
-    if not spawned then spawn(seek_time) end
+    if time == last_seek_time then return end
+    last_seek_time = time
+    if not spawned then spawn(time) end
     request_seek()
     if not file_timer:is_enabled() then file_timer:resume() end
 end
@@ -579,8 +550,6 @@ local function file_load()
     calc_dimensions()
     info(effective_w, effective_h)
     if disabled then return end
-
-    interval = math.min(math.max(mp.get_property_number("duration", 1) / options.max_thumbnails, options.interval), mp.get_property_number("duration", options.interval * options.min_thumbnails) / options.min_thumbnails)
 
     spawned = false
     if options.spawn_first then

--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -409,21 +409,18 @@ local function request_seek()
 end
 
 local function check_new_thumb()
-    local finfo = mp.utils.file_info(options.thumbnail)
-    if not finfo then return false end
-
     -- the slave might start writing to the file after checking existance and
     -- validity but before actually moving the file, so move to a temporary
     -- location before validity check to make sure everything stays consistant
     -- and valid thumbnails don't get overwritten by invalid ones
     local tmp = options.thumbnail..".tmp"
     move_file(options.thumbnail, tmp)
+    local finfo = mp.utils.file_info(tmp)
+    if not finfo then return false end
     if first_file then
         request_seek()
         first_file = false
     end
-    finfo = mp.utils.file_info(tmp)
-    if not finfo then return false end
     local w, h = real_res(effective_w, effective_h, finfo.size)
     if w then -- only accept valid thumbnails
         move_file(tmp, options.thumbnail..".bgra")

--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -74,11 +74,6 @@ if options.use_lua_io then
     end
 end
 
-local os_name = ""
-
-local unique = mp.get_property_native("pid")
-local init = false
-
 local spawned = false
 local network = false
 local disabled = false
@@ -169,6 +164,29 @@ local function get_os()
     return str_os_name
 end
 
+local os_name = get_os()
+
+if options.socket == "" then
+    if os_name == "Windows" then
+        options.socket = "thumbfast"
+    else
+        options.socket = "/tmp/thumbfast"
+    end
+end
+
+if options.thumbnail == "" then
+    if os_name == "Windows" then
+        options.thumbnail = os.getenv("TEMP").."\\thumbfast.out"
+    else
+        options.thumbnail = "/tmp/thumbfast.out"
+    end
+end
+
+local unique = mp.get_property_native("pid")
+
+options.socket = options.socket .. unique
+options.thumbnail = options.thumbnail .. unique
+
 local function vf_string(filters, full)
     local vf = ""
     local vf_table = mp.get_property_native("vf")
@@ -243,33 +261,6 @@ local function spawn(time)
     local ytdl = open_filename and network and path ~= open_filename
     if ytdl then
         path = open_filename
-    end
-
-    if os_name == "" then
-        os_name = get_os()
-    end
-
-    if options.socket == "" then
-        if os_name == "Windows" then
-            options.socket = "thumbfast"
-        else
-            options.socket = "/tmp/thumbfast"
-        end
-    end
-
-    if options.thumbnail == "" then
-        if os_name == "Windows" then
-            options.thumbnail = os.getenv("TEMP").."\\thumbfast.out"
-        else
-            options.thumbnail = "/tmp/thumbfast.out"
-        end
-    end
-
-    if not init then
-        -- ensure uniqueness
-        options.socket = options.socket .. unique
-        options.thumbnail = options.thumbnail .. unique
-        init = true
     end
 
     remove_thumbnail_files()


### PR DESCRIPTION
The changes from #41 are still relevant, but GitHub didn't let me reopen after I pushed so here is a new one.

Limiting the thumbnail count doesn't make sense when they are generated on the fly, and those limits enables us to do an exact seek after the user stops moving the mouse, allowing them to see the exact frame at the requested time.

Initializing things on startup allows us to simplify `spawn()` a bit, after all there is no benefit in checking every time if things need to be initialized.

With commands being very fast now, we could even remove the seek throttling. That would allow us to simplify the seeking code.
<details>
<summary>Seeking without throttling</summary>

```diff
diff --git a/thumbfast.lua b/thumbfast.lua
index 5e97de5..77db9e4 100644
--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -396,26 +396,14 @@ local function seek(fast)
 end
 
 local seek_period = 3/60
-local seek_requested = false
 local seek_timer
-seek_timer = mp.add_periodic_timer(seek_period, function()
-    if seek_requested then
-        seek_requested = false
-        seek(true)
-    else
-        seek_timer:kill()
-        seek()
-    end
-end)
+seek_timer = mp.add_timeout(seek_period, seek)
 seek_timer:kill()
 
 local function request_seek()
-    if seek_timer:is_enabled() then
-        seek_requested = true
-    else
-        seek_timer:resume()
-        seek(true)
-    end
+    seek_timer:kill()
+    seek_timer:resume()
+    seek(true)
 end
 
 local function check_new_thumb()
```
</details>