### PR TITLE
Update use_lua_io option description

### DIFF
--- a/thumbfast.conf
+++ b/thumbfast.conf
@@ -24,5 +24,5 @@ audio=no
 # Enable hardware decoding
 hwdec=no
 
-# Windows only: don't use subprocess to communicate with socket (warning: blocks, might cause hangs)
+# Windows only: use native Windows API to write to pipe (requires LuaJIT)
 use_lua_io=no

--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -31,7 +31,7 @@ local options = {
     -- Enable hardware decoding
     hwdec = false,
 
-    -- Windows only: don't use subprocess to communicate with socket
+    -- Windows only: use native Windows API to write to pipe (requires LuaJIT)
     use_lua_io = false
 }
 


### PR DESCRIPTION
This is nothing other than a pedantic cosmetic change. With the `SetNamedPipeHandleState` change, this option won't block.