### PR TITLE
Revert to subprocess seek by default on Windows

### DIFF
--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -418,12 +418,12 @@ local function run(command)
         return
     end
 
-    local file = nil
     if os_name == "Windows" then
-        file = io.open("\\\\.\\pipe\\"..options.socket, "r+")
-    else
-        file = io.open(options.socket, "r+")
+        subprocess({"cmd", "/c", "echo "..command.." > \\\\.\\pipe\\" .. options.socket}, true)
+        return
     end
+
+    local file = io.open(options.socket, "r+")
     if file ~= nil then
         file:seek("end")
         file:write(command.."\n")


### PR DESCRIPTION
Seeking on Windows (with `direct_io=no`) got changed in #44, but it seems there were performance issues when that was tried in #35.

Leaving this PR open until we can determine if that was a bad idea.
