### PR TITLE
Disable media-controls on Windows

### DIFF
--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -61,6 +61,8 @@ mp.options.read_options(options, "thumbfast")
 local properties = {}
 local pre_0_30_0 = mp.command_native_async == nil
 local pre_0_33_0 = true
+-- In mpv commit 5fed12e, mpv add `media-controls` option on Windows and set `player` as default
+local after_5fed12e = mp.get_property("media-controls") ~= nil
 
 function subprocess(args, async, callback)
     callback = callback or function() end
@@ -469,6 +471,11 @@ local function spawn(time)
 
     if os_name == "darwin" and properties["macos-app-activation-policy"] then
         table.insert(args, "--macos-app-activation-policy=accessory")
+    end
+
+    -- disable media-controls for subprocess
+    if os_name == "windows" and after_5fed12e then
+        table.insert(args, "--media-controls=no")
     end
 
     if os_name == "windows" or pre_0_33_0 then


### PR DESCRIPTION
Mpv add Media Control support on Windows (https://github.com/mpv-player/mpv/commit/5fed12e02531b6481c413337fc86c91f84a75d2f) , and set this option to `player` by default.
So the thumbfast's subprocess will also display in the System Media Transport Controls (SMTC) on Windows.
To avoid unwanted controls in SMTC, script should set `--media-controls=no` if the `media-controls` option is available and the system is Windows.