### PR TITLE
Fix subprocess initialization failure on Windows by inheriting enviro…

### DIFF
--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -68,9 +68,9 @@ function subprocess(args, async, callback)
 
     if not pre_0_30_0 then
         if async then
-            return mp.command_native_async({name = "subprocess", playback_only = true, args = args, env = "PATH="..os.getenv("PATH")}, callback)
+            return mp.command_native_async({name = "subprocess", playback_only = true, args = args}, callback)
         else
-            return mp.command_native({name = "subprocess", playback_only = false, capture_stdout = true, args = args, env = "PATH="..os.getenv("PATH")})
+            return mp.command_native({name = "subprocess", playback_only = false, capture_stdout = true, args = args})
         end
     else
         if async then

--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -66,11 +66,23 @@ local support_media_control = mp.get_property_native("media-controls") ~= nil
 function subprocess(args, async, callback)
     callback = callback or function() end
 
+    local env = nil
+
+    if mp.get_property("platform") == "darwin" then
+        local env_list = mp.utils.get_env_list()
+        env = {}
+        for _, v in ipairs(env_list) do
+            if not v:match("^XPC_SERVICE_NAME=") then
+                table.insert(env, v)
+            end
+        end
+    end
+
     if not pre_0_30_0 then
         if async then
-            return mp.command_native_async({name = "subprocess", playback_only = true, args = args}, callback)
+            return mp.command_native_async({name = "subprocess", playback_only = true, args = args, env = env}, callback)
         else
-            return mp.command_native({name = "subprocess", playback_only = false, capture_stdout = true, args = args})
+            return mp.command_native({name = "subprocess", playback_only = false, capture_stdout = true, args = args, env = env})
         end
     else
         if async then

--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -66,11 +66,17 @@ local support_media_control = mp.get_property_native("media-controls") ~= nil
 function subprocess(args, async, callback)
     callback = callback or function() end
 
+    local env = nil
+    local platform = mp.get_property("platform")
+    if platform ~= "windows" then
+        env = "PATH="..os.getenv("PATH")
+    end
+
     if not pre_0_30_0 then
         if async then
-            return mp.command_native_async({name = "subprocess", playback_only = true, args = args}, callback)
+            return mp.command_native_async({name = "subprocess", playback_only = true, args = args, env = env}, callback)
         else
-            return mp.command_native({name = "subprocess", playback_only = false, capture_stdout = true, args = args})
+            return mp.command_native({name = "subprocess", playback_only = false, capture_stdout = true, args = args, env = env})
         end
     else
         if async then

--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -66,17 +66,11 @@ local support_media_control = mp.get_property_native("media-controls") ~= nil
 function subprocess(args, async, callback)
     callback = callback or function() end
 
-    local env = nil
-    local platform = mp.get_property("platform")
-    if platform ~= "windows" then
-        env = "PATH="..os.getenv("PATH")
-    end
-
     if not pre_0_30_0 then
         if async then
-            return mp.command_native_async({name = "subprocess", playback_only = true, args = args, env = env}, callback)
+            return mp.command_native_async({name = "subprocess", playback_only = true, args = args}, callback)
         else
-            return mp.command_native({name = "subprocess", playback_only = false, capture_stdout = true, args = args, env = env})
+            return mp.command_native({name = "subprocess", playback_only = false, capture_stdout = true, args = args})
         end
     else
         if async then


### PR DESCRIPTION
The script was explicitly setting env = "PATH="..os.getenv("PATH") when spawning subprocesses. This effectively clears all other environment variables.

On Windows, critical variables like SystemRoot, COMSPEC, and PATHEXT are required for subprocesses to initialize correctly. Stripping them caused mp.command_native to fail with status: -3 (initialization failure), regardless of whether the executable was in the PATH or not.

This fix removes the env parameter, allowing the subprocess to inherit the full environment from the parent MPV process, which fixes the issue and is safer for cross-platform compatibility.