### PR TITLE
don't strip env on non-mac platforms

### DIFF
--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -67,10 +67,12 @@ function subprocess(args, async, callback)
     callback = callback or function() end
 
     if not pre_0_30_0 then
+        -- FIXME: figure out which exact env var needs to be stripped. (PR: #144, Issue: #106 and #139)
+        local env = os_name == "darwin" and "PATH="..os.getenv("PATH") or nil
         if async then
-            return mp.command_native_async({name = "subprocess", playback_only = true, args = args, env = "PATH="..os.getenv("PATH")}, callback)
+            return mp.command_native_async({name = "subprocess", playback_only = true, args = args, env = env}, callback)
         else
-            return mp.command_native({name = "subprocess", playback_only = false, capture_stdout = true, args = args, env = "PATH="..os.getenv("PATH")})
+            return mp.command_native({name = "subprocess", playback_only = false, capture_stdout = true, args = args, env = env})
         end
     else
         if async then


### PR DESCRIPTION
9deb0733c added this but with no explaination as to how or why this fixes the macos double icon issue. avoid stripping the environment on platform where this is not needed and may cause problems.