### PR TITLE
make compatible with mpv.net v7.1.2+ (fixes #163)

### DIFF
--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -67,10 +67,15 @@ function subprocess(args, async, callback)
     callback = callback or function() end
 
     if not pre_0_30_0 then
+        local env = {
+            "TMP="..os.getenv("TMP"),
+            "TEMP="..os.getenv("TEMP"),
+            "PATH="..os.getenv("PATH"),
+        }
         if async then
-            return mp.command_native_async({name = "subprocess", playback_only = true, args = args, env = "PATH="..os.getenv("PATH")}, callback)
+            return mp.command_native_async({name = "subprocess", playback_only = true, args = args, env = env}, callback)
         else
-            return mp.command_native({name = "subprocess", playback_only = false, capture_stdout = true, args = args, env = "PATH="..os.getenv("PATH")})
+            return mp.command_native({name = "subprocess", playback_only = false, capture_stdout = true, args = args, env = env})
         end
     else
         if async then


### PR DESCRIPTION
Fixes #163 

The issue is that mpv.net needs to know where the temp directory is, otherwise it fails with:

```
[thumbfast] [mpv.net] System.UnauthorizedAccessException: Access to the path 'C:\WINDOWS\uiy3lok1.3rw' is denied.
[thumbfast]    at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
[thumbfast]    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
[thumbfast]    at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
[thumbfast]    at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
[thumbfast]    at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
[thumbfast]    at System.Windows.Forms.ThemingScope.CreateActivationContext(Stream manifest)
[thumbfast]    at System.Windows.Forms.Application.EnableVisualStyles()
[thumbfast]    at MpvNet.Windows.Program.Main() in D:\Projects\CS\mpv.net\src\MpvNet.Windows\Program.cs:line 23
```

This happens because on Windows you need to preserve `TEMP` or `TMP` env var, otherwise it falls back to creating temp files in `WINDIR` for compatibility with Win3.1 (lol)