### PR TITLE
Restore local thumbnail path after clear

### DIFF
--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -866,6 +866,10 @@ local function thumb(time, r_x, r_y, script)
     time = tonumber(time)
     if time == nil then return end
 
+    if not using_storyboards then
+        thumbnail_path = options.thumbnail
+    end
+
     if r_x == "" or r_y == "" then
         x, y = nil, nil
     else


### PR DESCRIPTION
## Summary

- restore the regular thumbnail output path when a local thumbnail is requested
- keep storyboard thumbnail path selection unchanged
- prevent local previews from staying broken after the cursor leaves before the first thumbnail is ready

## Cause

`clear()` resets `thumbnail_path`, but it leaves the local thumbnail helper running. A later hover therefore skips `spawn()`, never restores the path, and `check_new_thumb()` ignores every new frame.

## Test

Tested on Windows with a local 4K AV1 MKV by sending `thumb`, `clear`, then another `thumb` request.

- before: no display thumbnail was produced after the second hover
- after: the second hover produced a valid 90,400-byte BGRA thumbnail