### PR TITLE
Improve start-up performance in directories with many files

### DIFF
--- a/thumbfast.lua
+++ b/thumbfast.lua
@@ -462,6 +462,7 @@ local function spawn(time)
     local args = {
         mpv_path, "--no-config", "--msg-level=all=no", "--idle", "--pause", "--keep-open=always", "--really-quiet", "--no-terminal",
         "--load-scripts=no", "--osc=no", "--ytdl=no", "--load-stats-overlay=no", "--load-osd-console=no", "--load-auto-profiles=no",
+        "--autocreate-playlist=no", "--autoload-files=no",
         "--edition="..(properties["edition"] or "auto"), "--vid="..(vid or "auto"), "--no-sub", "--no-audio",
         "--start="..time, allow_fast_seek and "--hr-seek=no" or "--hr-seek=yes",
         "--ytdl-format=worst", "--demuxer-readahead-secs=0", "--demuxer-max-bytes=128KiB",


### PR DESCRIPTION
I noticed that thumbnail first loads very slowly for a file in a directory that has many other video files. This is because mpv scans the whole dir. This change prevents this from happening and speeds up thumbnail generation significantly